### PR TITLE
srx cluster functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ DEVICE controls:
                         EXPLICIT: Junos NOOB configuration file
   --qfx-node            Set QFX device into "node" mode
   --qfx-switch          Set QFX device into "switch" mode
+  --srx_cluster REQUEST_SRX_CLUSTER
+                        cluster_id,node ... Invoke cluster on SRX device and
+                        reboot
+  --srx_cluster_disable
+                        Disable cluster mode on SRX device and reboot
 
 MODE controls:
   --dry-run             dry-run builds the config only

--- a/lib/netconify/constants.py
+++ b/lib/netconify/constants.py
@@ -1,3 +1,3 @@
-version = "0.1.1"
-date = "2014-July-2"
+version = "0.1.2"
+date = "2015-Jan-4"
 author = "Jeremy Schulman, @nwkautomaniac"

--- a/lib/netconify/tty.py
+++ b/lib/netconify/tty.py
@@ -101,7 +101,7 @@ class Terminal(object):
     self._login_state_machine()
 
     # now start NETCONF XML 
-    self.notify('login','starting NETCONF')
+    self.notify('login',' OK ... starting NETCONF')
     self.nc.open(at_shell = self.at_shell)    
     return True
 
@@ -184,6 +184,10 @@ class Terminal(object):
         # a login prompt for whatever reason
         self.state = self._ST_TTY_NOLOGIN
         self.write('<close-session/>')    #@@@ this is a hack
+        ## if console connection have a banner or warning
+        ## comment-out line above and uncoment lines bellow ... better hack 
+        #sleep(5)
+        #self.write('\n')
 
     def _ev_shell():
       if self.state == self._ST_INIT:

--- a/lib/netconify/tty_netconf.py
+++ b/lib/netconify/tty_netconf.py
@@ -119,6 +119,20 @@ class tty_netconf(object):
       pass
     return True
 
+  def disablecluster(self):
+    """ issue set chassis cluster disable to the device nad reboot """
+    cmd = E.command('set chassis cluster disable reboot')
+    rsp = self.rpc(etree.tostring(cmd))
+    # No need to check error exception, device will be rebooted even if not in cluster
+    return True
+
+  def enablecluster(self, cluster_id, node):
+    """ issue request chassis cluster command """
+    cmd = E('set-chassis-cluster-enable', E('cluster-id', str(cluster_id)), E('node', str(node)), E('reboot'))
+    rsp = self.rpc(etree.tostring(cmd))
+    #device will be set to new cluster ID:NODE value
+    return True
+    
   ### -------------------------------------------------------------------------
   ### XML RPC command execution
   ### -------------------------------------------------------------------------


### PR DESCRIPTION
Added function to allow setting SRX devices to the cluster mode and also function to disable cluster mode.
After each function, device will reboot as part of command.

--srx_cluster 1:0                  will set device to cluster_id 1 on node 0, then reboot the device
--srx_cluster_disable           will set device to stand alone mode

No need to add rsp output for user, since these command will always execute and reboot the device. For example, if device is already set to cluster_id 10 and called node 1, by issuing netconify -t={TERM_SRV}:{TERM_PORT} --srx_cluster 5:0, device will be RE-SET to cluster_id 5, called node 0 and reloaded.

Since SRX device must be first set to cluster mode before additional configuration is entered, it only makes sense to make it part of netconify device option, since netconify it can handle devices in amnesiac mode.
