### PR TITLE
Avocent console server handling, warning before commit ignore

### DIFF
--- a/lib/netconify/tty.py
+++ b/lib/netconify/tty.py
@@ -35,6 +35,7 @@ class Terminal(object):
     _ST_DONE = 3
     _ST_BAD_PASSWD = 4
     _ST_TTY_NOLOGIN = 5
+    _ST_CTRLZ = 6
 
     _re_pat_login = '(?P<login>ogin:\s*$)'
 
@@ -43,7 +44,8 @@ class Terminal(object):
         '(?P<passwd>assword:\s*$)',
         '(?P<badpasswd>ogin incorrect)',
         '(?P<shell>%\s*$)',
-        '(?P<cli>[^\\-"]>\s*$)'
+        '(?P<cli>[^\\-"]>\s*$)',
+        '(?P<ctrlz><CTRL>Z[\s\n]*$)'
     ]
 
     # -----------------------------------------------------------------------
@@ -186,6 +188,10 @@ class Terminal(object):
                 self.state = self._ST_TTY_NOLOGIN
                 self.write('<close-session/>')  # @@@ this is a hack
 
+        def _ev_ctrlz():
+            self.state = self._ST_CTRLZ
+            self.write('\015')
+
         def _ev_shell():
             if self.state == self._ST_INIT:
                 # this means that the shell was left
@@ -214,7 +220,8 @@ class Terminal(object):
             'passwd': _ev_passwd,
             'badpasswd': _ev_bad_passwd,
             'shell': _ev_shell,
-            'cli': _ev_cli
+            'cli': _ev_cli,
+            'ctrlz': _ev_ctrlz
         }
 
         _ev_tbl.get(found, _ev_tty_nologin)()

--- a/lib/netconify/tty_netconf.py
+++ b/lib/netconify/tty_netconf.py
@@ -89,10 +89,11 @@ class tty_netconf(object):
         :True: otherwise return the response as XML for further processing.
         """
         rsp = self.rpc('<commit-configuration/>')
-        if 'ok' == rsp.tag:
-            return True     # some devices use 'ok'
-        if len(rsp.xpath('.//commit-success')) > 0:
-            return True
+        for child in rsp:
+            if 'ok' == rsp.tag:
+                return True     # some devices use 'ok'
+            if len(rsp.xpath('.//commit-success')) > 0:
+                return True
         return rsp
 
     def rollback(self):
@@ -162,7 +163,10 @@ class tty_netconf(object):
             cmd = '<{0}/>'.format(cmd)
         self._tty.rawwrite('<rpc>{0}</rpc>'.format(cmd))
         rsp = self._receive()
-        return rsp[0]  # return first child after the <rpc-reply>
+        try:
+            return rsp  # return all children after the <rpc-reply>
+        except:
+            return etree.XML('<error-in-receive/>')
 
     # -------------------------------------------------------------------------
     # LOW-LEVEL I/O for reading back XML response


### PR DESCRIPTION
After this changes it is possible to use Netconf by console when there is Avocent console server in the way (usage in ansible-junos-stdlib):

```
      - name: Zeroconfig Junos
        junos_install_config:
          host=host
          user=user
          passwd=passwd
          file=somefile.conf
          console="--telnet=avocent_ip_addr,avocent_port"
          logfile=config.log
```

Second commit handles/ignores errors before successful commit message:

```
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/12.3R8/junos">
rcmd: getaddrinfo: hostname nor servname provided, or not known
rcmd: getaddrinfo: hostname nor servname provided, or not known
rcmd: getaddrinfo: hostname nor servname provided, or not known
rcmd: getaddrinfo: hostname nor servname provided, or not known
<rpc-error>
<error-type>protocol</error-type>
<error-tag>operation-failed</error-tag>
<error-severity>warning</error-severity>
<error-message>
Could not connect to fpc-1 : Can't assign requested address
</error-message>
</rpc-error>
<rpc-error>
<error-type>protocol</error-type>
<error-tag>operation-failed</error-tag>
<error-severity>warning</error-severity>
<error-message>
Cannot connect to other RE, ignoring it
</error-message>
</rpc-error>
<commit-results>
<routing-engine junos:style="normal">
<name>fpc0</name>
<commit-check-success/>
<commit-success/>
</routing-engine>
</commit-results>
<ok/>
</rpc-reply>
```
