### PR TITLE
Handle new version output for 15.1+ releases on MX (FreeBSD10 based)

### DIFF
--- a/lib/netconify/facts.py
+++ b/lib/netconify/facts.py
@@ -18,9 +18,18 @@ class Facts(object):
         self.swinfo = rsp  # keep this since we may want it later
 
         # extract the version
-        pkginfo = rsp.xpath(
-            './/package-information[name = "junos"]/comment')[0].text
-        self.facts['version'] = re.findall(r'\[(.*)\]', pkginfo)[0]
+        # First try the <junos-version> tag present in >= 15.1
+        swinfo = rsp.findtext('junos-version', default=None)
+        if not swinfo:
+            # For < 15.1, get version from the "junos" package.
+            pkginfo = rsp.xpath(
+                'package-information[normalize-space(name)="junos"]/comment'
+            )[0].text
+            try:
+                swinfo = re.findall(r'\[(.*)\]', pkginfo)[0]
+            except:
+                swinfo = "0.0I0.0"
+        self.facts['version'] = swinfo
 
         # extract the host-name
         self.facts['hostname'] = rsp.xpath('.//host-name')[0].text

--- a/lib/netconify/facts.py
+++ b/lib/netconify/facts.py
@@ -19,11 +19,11 @@ class Facts(object):
 
         # extract the version
         # First try the <junos-version> tag present in >= 15.1
-        swinfo = rsp.findtext('junos-version', default=None)
+        swinfo = rsp.xpath('.//junos-version')[0].text
         if not swinfo:
             # For < 15.1, get version from the "junos" package.
             pkginfo = rsp.xpath(
-                'package-information[normalize-space(name)="junos"]/comment'
+                './/package-information[normalize-space(name)="junos"]/comment'
             )[0].text
             try:
                 swinfo = re.findall(r'\[(.*)\]', pkginfo)[0]

--- a/lib/netconify/tty.py
+++ b/lib/netconify/tty.py
@@ -42,7 +42,7 @@ class Terminal(object):
         _re_pat_login,
         '(?P<passwd>assword:\s*$)',
         '(?P<badpasswd>ogin incorrect)',
-        '(?P<shell>%\s*$)',
+        '(?P<shell>%|#\s*$)',
         '(?P<cli>[^\\-"]>\s*$)'
     ]
 


### PR DESCRIPTION
Addresses issue #33.

This is a very similar to the fix that was applied to PyEZ in https://github.com/Juniper/py-junos-eznc/pull/399