### PR TITLE
Address #36.

### DIFF
--- a/lib/netconify/facts.py
+++ b/lib/netconify/facts.py
@@ -19,7 +19,7 @@ class Facts(object):
 
         # extract the version
         # First try the <junos-version> tag present in >= 15.1
-        swinfo = rsp.xpath('.//junos-version')[0].text
+	swinfo = rsp.findtext('junos-version', default=None)
         if not swinfo:
             # For < 15.1, get version from the "junos" package.
             pkginfo = rsp.xpath(


### PR DESCRIPTION
Does not raise an exception if the <junos-version> tag is not present.

I have tested on >=15.1, 14.2, and 12.1X46. This fix also more closely
follows the fix in PyEZ which appears to be working correctly.